### PR TITLE
Default to empty recipe list on null response

### DIFF
--- a/src/app/shared/data-storage.service.ts
+++ b/src/app/shared/data-storage.service.ts
@@ -33,6 +33,7 @@ export class DataStorageService {
       )
       .pipe(
         map(recipes => {
+          recipes = recipes ?? [];
           return recipes.map(recipe => {
             return {
               ...recipe,


### PR DESCRIPTION
## Summary
- Safeguard `fetchRecipes` against null HTTP responses by defaulting to an empty array before mapping
- Preserve existing tap logic for setting recipes in the service

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build -- --progress=false`


------
https://chatgpt.com/codex/tasks/task_e_68942a829c848322a85a0d4ea786d66b